### PR TITLE
Added transformFn option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## What
 Normally, Webpack looks for **index** file when the path passed to `require` points to a directory; which means there may have a lot of **index** files.
 
-This plugin makes it possible to use the name of the directory as the name of the entry file, makes it easier to find.
+This plugin makes it possible to control what file within directory will be treated as entry file.
 
 ## Usage
 
@@ -17,9 +17,9 @@ Add the following to Webpack's config file:
 
 ```
 
-Then when `require("component/foo")` and the path "component/foo" is resolved to a directory, Webpack will try to look for `component/foo/foo.js` as the entry.
+Then when `require("component/foo")` and the path "component/foo" is resolved to a directory, Webpack will try to look for `component/foo/foo.js` as the entry (given default options).
 
-If there is also an index file, e.g. `index.js`, and it should be used as entry file instead of the file with the same name of directory, pass `true` as the first argument when creating new instace.
+If there is also an index file, e.g. `index.js`, and it should be used as entry file instead of the file with the same name of directory, pass `true` as the first argument when creating new instance.
 
 ```javascript
   var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
@@ -27,11 +27,10 @@ If there is also an index file, e.g. `index.js`, and it should be used as entry 
   plugins: [
     new webpack.ResolverPlugin(new DirectoryNamedWebpackPlugin(true))
   ]
-
 ```
 
-Can also pass in an options object to further customise the plugin
-``` javascript
+You can also pass in an options object to further customise the plugin:
+```javascript
   var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
 
   plugins: [
@@ -43,8 +42,14 @@ Can also pass in an options object to further customise the plugin
         // custom logic to decide whether request should be ignored
         // return true if request should be ignored, false otherwise
         return false; // default
+      },
+      
+      transformFn: function(dirName) {
+        // use this function to provide custom transforms of resolving directory name
+        // return desired filename or array of filenames which will be used
+        // one by one (honoring order) in attempts to resolve module        
+        return dirName; // default
       }
     }))
   ]
-
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function DirectoryNamedWebpackPlugin(options) {
   this.options = {
     honorIndex: optionsToUse.honorIndex,
     honorPackage: optionsToUse.honorPackage !== false,
+    transformFn: optionsToUse.transformFn,
     ignoreFn: optionsToUse.ignoreFn || noop
   };
 }
@@ -43,7 +44,21 @@ function resolveDirectory(options) {
         attempts.push("index");
       }
 
-      attempts.push(dirName)
+      if (options.transformFn) {
+        var transformResult = options.transformFn(dirName);
+
+        if (!Array.isArray(transformResult)) {
+          transformResult = [ transformResult ];
+        }
+
+        transformResult = transformResult.filter(function (attemptName) {
+          return typeof attemptName === 'string' && attemptName.length > 0;
+        });
+
+        attempts = attempts.concat(transformResult);
+      } else {
+        attempts.push(dirName);
+      }
 
       _this.forEachBail(
         attempts,


### PR DESCRIPTION
I've found that there is no way to customize transformation from directory name to desired file name. It's hardcoded within plugin, and is always `fileName = dirName`.

This PR introduces `transformFn` option, which could be used in next fashion:

```javascript
var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");

plugins: [
  new webpack.ResolverPlugin(new DirectoryNamedWebpackPlugin({
    transformFn: function(dirName) {
      // use this function to provide custom transforms of resolving directory name
      // return desired filename or array of filenames which will be used
      // one by one (honoring order) in attempts to resolve module        
      return dirName; // default
    }
  }))
]
```

Now it becomes possible to use, for instance, next structure:
* components
* * smart-component
* * * SmartComponent

```javascript
transformFn(dirName) {
  return dirName.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
}
```