### PR TITLE
Critical fix for v1: webpack build fails if some package had package.json's main property undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ function resolveDirectory(options) {
       if (options.honorPackage) {
         try {
           var mainFilePath = require(path.resolve(dirPath, 'package.json')).main;
-          attempts.push(mainFilePath);
+
+          if (mainFilePath) {
+            attempts.push(mainFilePath);
+          }
         } catch (e) {
           // No problem, this is optional.
         }


### PR DESCRIPTION
On Windows machine there is next issue:
If there is some package with `main` field value of `package.json` equal `undefined`, it will cause `webpack` build to fail.
In code, released for webpack v2, fix already included (checking for `undefined` value).

Need to update v1 to include this fix ASAP.