### PR TITLE
add include and exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If there is also an index file, e.g. `index.js`, and it should be used as entry 
 You can also pass in an options object to further customise the plugin:
 ```javascript
   var DirectoryNamedWebpackPlugin = require("directory-named-webpack-plugin");
+  var path = require("path");
 
   resolve: {
     plugins: [
@@ -50,11 +51,22 @@ You can also pass in an options object to further customise the plugin:
         // defaults to true, which is the same as ["main"]
         honorPackage: true | false | ["main"],
 
+        // if it's matching with resolving directory's path, plugin will ignore the custom resolving.
+        // it can be string/regex or Array of string/regex.
+        exclude: /node_modules/
+
         ignoreFn: function(webpackResolveRequest) {
           // custom logic to decide whether request should be ignored
           // return true if request should be ignored, false otherwise
           return false; // default
         },
+
+        // define where the imported files will be resolving by DirectoryNamedWebpackPlugin.
+        // it can be string/regex or Array of string/regex.
+        include: [
+          path.resolve('./app/components'),
+          path.resolve('./app/containers')
+        ]
 
         transformFn: function(dirName) {
           // use this function to provide custom transforms of resolving directory name

--- a/__mocks__/basicDir/basic.js
+++ b/__mocks__/basicDir/basic.js
@@ -1,0 +1,1 @@
+module.exports = "basic.js";

--- a/index.js
+++ b/index.js
@@ -5,8 +5,12 @@ var basename = require('enhanced-resolve/lib/getPaths').basename;
 
 module.exports = function (options) {
   var optionsToUse = (typeof options === 'boolean') ? { honorIndex: options } : (options || {});
-  var mainFields = optionsToUse.honorPackage;
+  var {honorPackage: mainFields, exclude, include} = optionsToUse;
   optionsToUse.mainFields = mainFields !== false && !Array.isArray(mainFields) ? ["main"] : mainFields;
+  // make exclude array if not
+  optionsToUse.exclude = exclude && !Array.isArray(exclude) ? [exclude] : exclude;
+  // make include array if not
+  optionsToUse.include = include && !Array.isArray(include) ? [include] : include;
   return {
     apply: doApply.bind(this, optionsToUse)
   };
@@ -22,6 +26,16 @@ function doApply(options, resolver) {
     var dirPath = request.path;
     var dirName = basename(dirPath);
     var attempts = [];
+
+    // return if path matches with excludes
+    if (options.exclude && options.exclude.some(exclude=> dirPath.search(exclude) >= 0)) {
+      return callback();
+    }
+
+    // return if path doesn't match with includes
+    if (options.include && !options.include.some(include=> dirPath.search(include) >= 0)){
+      return callback();
+    }
 
     if (options.mainFields) {
       try {

--- a/index.test.js
+++ b/index.test.js
@@ -8,45 +8,44 @@ var createResolver = options =>
     plugins: [new plugin(options)]
   });
 
-describe("Directory Named Webpack Plugin", () => {
-  it("basicDir/ should match with basicDir.js", done => {
+describe("Simple matches", () => {
+  it("basicDir/ should match to basicDir/basicDir.js", done => {
     var resolver = createResolver();
-    resolver.resolve({}, __dirname, "./__mocks__/basicTest", function(
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
       err,
       result
     ) {
-      if (err) return done(err);
       expect(result).toEqual(
-        path.resolve(__dirname, "./__mocks__/basicTest/basicTest.js")
+        path.resolve(__dirname, "./__mocks__/basicDir/basicDir.js")
       );
       done();
     });
   });
 
-  it("HonorDir/ should honor package and match to foo.js", done => {
+  it("HonorDir/ should honor package and match to HonorDir/foo.js", done => {
     var resolver = createResolver();
-    resolver.resolve({}, __dirname, "./__mocks__/HonorPackage", function(
+    resolver.resolve({}, __dirname, "./__mocks__/HonorDir", function(
       err,
       result
     ) {
-      if (err) return done(err);
       expect(result).toEqual(
         path.resolve(__dirname, "./__mocks__/HonorDir/foo.js")
       );
       done();
     });
   });
+});
 
-  it("HonorDir/ should honor index and match to index.js", done => {
+describe("Honor options (honorIndex and honorPackage)", () => {
+  it("HonorDir/ should honor index and match to HonorDir/index.js", done => {
     var resolver = createResolver({
       honorIndex: true,
       honorPackage: false
     });
-    resolver.resolve({}, __dirname, "./__mocks__/HonorPackage", function(
+    resolver.resolve({}, __dirname, "./__mocks__/HonorDir", function(
       err,
       result
     ) {
-      if (err) return done(err);
       expect(result).toEqual(
         path.resolve(__dirname, "./__mocks__/HonorDir/index.js")
       );
@@ -54,16 +53,15 @@ describe("Directory Named Webpack Plugin", () => {
     });
   });
 
-  it("HonorDir/ should match to HonorDir.js when honor properties are false", done => {
+  it("HonorDir/ should match to HonorDir/HonorDir.js when honor properties are false", done => {
     var resolver = createResolver({
       honorIndex: false,
       honorPackage: false
     });
-    resolver.resolve({}, __dirname, "./__mocks__/HonorPackage", function(
+    resolver.resolve({}, __dirname, "./__mocks__/HonorDir", function(
       err,
       result
     ) {
-      if (err) return done(err);
       expect(result).toEqual(
         path.resolve(__dirname, "./__mocks__/HonorDir/HonorDir.js")
       );

--- a/index.test.js
+++ b/index.test.js
@@ -69,3 +69,101 @@ describe("Honor options (honorIndex and honorPackage)", () => {
     });
   });
 });
+
+describe("include, exclude and ignoreFn options", () => {
+  it("basicDir/ should return undefined with regex exclude", done => {
+    var resolver = createResolver({ exclude: /basicDir/ });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toBeUndefined();
+      done();
+    });
+  });
+
+  it("basicDir/ should return undefined with array of regex exclude", done => {
+    var resolver = createResolver({
+      exclude: [/other_regex_pattern/, /\/.+Dir/]
+    });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toBeUndefined();
+      done();
+    });
+  });
+
+  it("basicDir/ should match to basicDir/basicDir.js with unrelated exclude", done => {
+    var resolver = createResolver({ exclude: /node_modules/ });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toEqual(
+        path.resolve(__dirname, "./__mocks__/basicDir/basicDir.js")
+      );
+      done();
+    });
+  });
+
+  it("HonorDir/ should match with regular resolver because of include mismatch", done => {
+    var resolver = createResolver({
+      include: /other_regex_pattern/,
+      honorPackage: false
+    });
+    resolver.resolve({}, __dirname, "./__mocks__/HonorDir", function(
+      err,
+      result
+    ) {
+      expect(result).toEqual(
+        path.resolve(__dirname, "./__mocks__/HonorDir/foo.js")
+      );
+      done();
+    });
+  });
+
+  it("basicDir/ should match to basicDir/basicDir.js with string include", done => {
+    var resolver = createResolver({ include: "__mocks__/" });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toEqual(
+        path.resolve(__dirname, "./__mocks__/basicDir/basicDir.js")
+      );
+      done();
+    });
+  });
+
+  it("basicDir/ should match to basicDir/basicDir.js with array of regex include", done => {
+    var resolver = createResolver({
+      include: [/components\//, /dir/i, /other_regex_pattern/]
+    });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toEqual(
+        path.resolve(__dirname, "./__mocks__/basicDir/basicDir.js")
+      );
+      done();
+    });
+  });
+
+  it("basicDir/ should match to basicDir/basic.js with transformFn", done => {
+    var resolver = createResolver({
+      transformFn: dirName => [dirName.replace("Dir", ""), dirName]
+    });
+    resolver.resolve({}, __dirname, "./__mocks__/basicDir", function(
+      err,
+      result
+    ) {
+      expect(result).toEqual(
+        path.resolve(__dirname, "./__mocks__/basicDir/basic.js")
+      );
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#14 

Added include and exclude properties. Both of them can be string/regex or Array of string/regex.

```js
new DirectoryNamedWebpackPlugin({
    exclude: /node_modules/,
    // exclude is not necessary for this use case
    include: [
        /app\/components\//,
        /app\/container\//
    ]
})
```