### PR TITLE
Use `includes` for Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,14 +34,14 @@ function doApply(options, resolver) {
   
       // return if path matches with excludes
       if (options.exclude && options.exclude.some(function(exclude) {
-        return dirPath.search(exclude) >= 0;
+        return dirPath.includes(exclude);
       })) {
         return callback();
       }
   
       // return if path doesn't match with includes
       if (options.include && !options.include.some(function(include) {
-        return dirPath.search(include) >= 0;
+        return dirPath.includes(include);
       })) {
         return callback();
       }


### PR DESCRIPTION
Hello,

When using an `options.include` or `options.exclude` the module resolution fails in Windows. Calling `.search` converts the `dirPath` to a regex, but on Windows the `/` create an invalid regex. This PR uses `includes` to check if the dirPath is part of the include or exclude options.